### PR TITLE
Fix structural causal equation for Y in 3.8.1

### DIFF
--- a/python/causality/20210130--linear causal models (3.8).ipynb
+++ b/python/causality/20210130--linear causal models (3.8).ipynb
@@ -75,7 +75,7 @@
     "    X = t1 * W1 + t2 * Z3 + U_prime\n",
     "    W3 = c3 * X + U3_prime\n",
     "    W2 = c2 * Z2 + U2_prime\n",
-    "    Y = a * W3 + c * W2 + U\n",
+    "    Y = a * W3 + b * Z3 + c * W2 + U\n",
     "    return {\n",
     "        'Z1': Z1,\n",
     "        'Z2': Z2,\n",


### PR DESCRIPTION
I was getting the wrong answers until I realized there's a slight error in the definition of Y, where the Z3 term was omitted.